### PR TITLE
nginxサービスのvolumesの指定を変更

### DIFF
--- a/posse-ph3-webapp-env/docker-compose.yml
+++ b/posse-ph3-webapp-env/docker-compose.yml
@@ -25,5 +25,5 @@ services:
     ports:
       - 80:80
     volumes:
-      - ../posse-ph3-webapp-env:/work/backend
+      - ../posse-ph3-webapp:/work/backend
     depends_on: ["phpfpm"]


### PR DESCRIPTION
# 対応内容

posse-ph3-webapp-envのマウントを削除
posse-ph3-webappを/work/backendにマウント

# バグ原因

[コメットメッセージ](https://github.com/posse-ap/gen1.5-MayuNA-mayuna/pull/5/commits/2cce06f6f06a4bcda1e223ab5d509b6a30eedc53)に記載してます

# 確認した内容

yarn installし、yarn run dev後に /loginにアクセス
bootstrapデザインが当たっていることを確認

<img width="1430" alt="スクリーンショット 2022-01-14 21 24 34" src="https://user-images.githubusercontent.com/23156390/149518354-ed34a224-9526-4def-a2f4-6e68ca76742e.png">

